### PR TITLE
The existing test-runner.sh would only run the tests in the first .js

### DIFF
--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-nodejs ./*.js
+# Run from project /test/ dir, using: ./test-runner.sh
+# This file needs to have executable permissions.
+./../node_modules/.bin/tape ./*.js


### PR DESCRIPTION
file in the directory. I don't know why. Modified this file to use the
tape 'binary' to run all tests in the suite. Nicely, it prints the total
of all tests run at the end.

For this to work, I had to install 'node-legacy'
(sudo apt-get install nodejs-legacy). Looks like the 'node' name is now
taken byt another package (https://askubuntu.com/a/405035/427900). Who
knows. Anyhow, I guess node-legacy lets you install and use the 'node'
name for nodejs. yrg.